### PR TITLE
Move to Alacritty org travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,57 @@
 language: rust
 
-cache: cargo
+addons:
+  apt:
+    packages:
+    - libxcb-xfixes0-dev
+
+git:
+  depth: 1
+
+os:
+  - linux
+  - osx
 
 rust:
+  - 1.36.0
   - stable
   - nightly
 
-script:
-  - cargo test --workspace --no-default-features
-  - cargo test --workspace
+matrix:
+  fast_finish: true
+  include:
+    - if: tag IS present
+      os: linux
+      rust: stable
+      env: ARCH=i386
+    - name: "Clippy Linux"
+      os: linux
+      env: CLIPPY=true
+      rust: stable
+    - name: "Clippy OSX"
+      os: osx
+      env: CLIPPY=true
+      rust: stable
+    - name: "Clippy Windows"
+      os: windows
+      env: CLIPPY=true
+      rust: stable-x86_64-pc-windows-msvc
+    - name: "Rustfmt"
+      os: linux
+      env: RUSTFMT=true
+      rust: nightly
+    - name: "Windows 1.36.0"
+      os: windows
+      rust: 1.36.0-x86_64-pc-windows-msvc
+    - name: "Windows Stable"
+      os: windows
+      rust: stable-x86_64-pc-windows-msvc
+    - name: "Windows Nightly"
+      os: windows
+      rust: nightly-x86_64-pc-windows-msvc
+  allow_failures:
+    - rust: nightly
+    - rust: nightly-x86_64-pc-windows-msvc
+
+install: ci/install.sh
+script: ci/script.sh

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Add clippy for lint validation
+if [ "$CLIPPY" == "true" ]; then
+    rustup component add clippy
+fi
+
+# Add rustfmt for format validation
+if [ "$RUSTFMT" == "true" ]; then
+    rustup component add rustfmt
+fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Run clippy checks
+if [ "$CLIPPY" == "true" ]; then
+    cargo clippy --all-targets
+    exit
+fi
+
+# Run clippy rustfmt
+if [ "$RUSTFMT" == "true" ]; then
+    cargo fmt -- --check
+    exit
+fi
+
+# Run tests
+cargo test


### PR DESCRIPTION
This replaces the existing travis setup with the default for the
Alacritty organization.

This includes making it a requirement to build on 1.36.0.