### PR TITLE
Pass terminator to osc dispatcher

### DIFF
--- a/examples/parselog.rs
+++ b/examples/parselog.rs
@@ -30,8 +30,8 @@ impl vte::Perform for Log {
         println!("[unhook]");
     }
 
-    fn osc_dispatch(&mut self, params: &[&[u8]]) {
-        println!("[osc_dispatch] params={:?}", params);
+    fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
+        println!("[osc_dispatch] params={:?} bell_terminated={}", params, bell_terminated);
     }
 
     fn csi_dispatch(&mut self, params: &[i64], intermediates: &[u8], ignore: bool, c: char) {

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -50,7 +50,7 @@ pub enum Action {
 
 impl State {
     #[inline]
-    pub fn entry_action(&self) -> Action {
+    pub fn entry_action(self) -> Action {
         match self {
             State::CsiEntry | State::DcsEntry | State::Escape => Action::Clear,
             State::DcsPassthrough => Action::Hook,
@@ -60,7 +60,7 @@ impl State {
     }
 
     #[inline]
-    pub fn exit_action(&self) -> Action {
+    pub fn exit_action(self) -> Action {
         match self {
             State::DcsPassthrough => Action::Unhook,
             State::OscString => Action::OscEnd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,8 +813,8 @@ mod bench {
 
         fn unhook(&mut self) {}
 
-        fn osc_dispatch(&mut self, params: &[&[u8]]) {
-            black_box(params);
+        fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
+            black_box((params, bell_terminated));
         }
 
         fn csi_dispatch(&mut self, params: &[i64], intermediates: &[u8], ignore: bool, c: char) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ impl Parser {
     ///
     /// The aliasing is needed here for multiple slices into self.osc_raw
     #[inline]
-    fn osc_dispatch<P: Perform>(&self, performer: &mut P, bell_terminated: bool) {
+    fn osc_dispatch<P: Perform>(&self, performer: &mut P, byte: u8) {
         let mut slices: [MaybeUninit<&[u8]>; MAX_PARAMS] =
             unsafe { MaybeUninit::uninit().assume_init() };
 
@@ -192,7 +192,7 @@ impl Parser {
         unsafe {
             let num_params = self.osc_num_params;
             let params = &slices[..num_params] as *const [MaybeUninit<&[u8]>] as *const [&[u8]];
-            performer.osc_dispatch(&*params, bell_terminated);
+            performer.osc_dispatch(&*params, byte == 0x07);
         }
     }
 
@@ -269,7 +269,7 @@ impl Parser {
                         self.osc_num_params += 1;
                     },
                 }
-                self.osc_dispatch(performer, byte == 0x7);
+                self.osc_dispatch(performer, byte);
             },
             Action::Unhook => performer.unhook(),
             Action::CsiDispatch => {

--- a/src/table.rs
+++ b/src/table.rs
@@ -170,6 +170,8 @@ generate_state_changes!(state_changes, {
         0x08..=0x17 => (Anywhere, Ignore),
         0x19        => (Anywhere, Ignore),
         0x1c..=0x1f => (Anywhere, Ignore),
-        0x20..=0xff => (Anywhere, OscPut),
+        0x20..=0x9b => (Anywhere, OscPut),
+        0x9c        => (Ground, None),
+        0x9d..=0xff => (Anywhere, OscPut),
     }
 });

--- a/utf8parse/src/lib.rs
+++ b/utf8parse/src/lib.rs
@@ -3,6 +3,7 @@
 //! This module implements a table-driven UTF-8 parser which should
 //! theoretically contain the minimal number of branches (1). The only branch is
 //! on the `Action` returned from unpacking a transition.
+#![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 #![no_std]
 

--- a/utf8parse/src/types.rs
+++ b/utf8parse/src/types.rs
@@ -58,7 +58,7 @@ impl State {
     /// This takes the current state and input byte into consideration, to determine the next state
     /// and any action that should be taken.
     #[inline]
-    pub fn advance(&self, byte: u8) -> (State, Action) {
+    pub fn advance(self, byte: u8) -> (State, Action) {
         match self {
             State::Ground => match byte {
                 0x00..=0x7f => (State::Ground, Action::EmitByte),

--- a/vte_generate_state_changes/src/lib.rs
+++ b/vte_generate_state_changes/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
+
 extern crate proc_macro;
 
 use std::iter::Peekable;
@@ -53,7 +55,7 @@ fn states_stream(iter: &mut impl Iterator<Item = TokenTree>) -> TokenStream {
 /// Generate the array assignment statements for one origin state.
 fn state_entry_stream(iter: &mut Peekable<token_stream::IntoIter>) -> TokenStream {
     // Origin state name
-    let state = iter.next().unwrap().into();
+    let state = iter.next().unwrap();
 
     // Token stream with all the byte->target mappings
     let mut changes_stream = next_group(iter).into_iter().peekable();


### PR DESCRIPTION
Even though the ST terminator is the only officially supported
terminator, some applications still rely on BEL to work properly. Both
have been supported historically, however there was no way for the
terminal to tell which terminator was used.

Since OSC escapes frequently offer the `?` parameter to query for the
current format, some applications expect the response terminator to
match the request terminator. To make it possible to support this, the
osc dispatcher is now informed when the BEL terminator was used.

Since the C1 ST terminator was not yet supported for OSC escapes,
support for it has also been added.