### PR TITLE
Remove ESC params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## [Unreleased]
 
 - Fix params reset between escapes
+- Removed unused parameter from `esc_dispatch`
 
 ## 0.6.0
 

--- a/examples/parselog.rs
+++ b/examples/parselog.rs
@@ -41,10 +41,10 @@ impl vte::Perform for Log {
         );
     }
 
-    fn esc_dispatch(&mut self, params: &[i64], intermediates: &[u8], ignore: bool, byte: u8) {
+    fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
         println!(
-            "[esc_dispatch] params={:?}, intermediates={:?}, ignore={:?}, byte={:02x}",
-            params, intermediates, ignore, byte
+            "[esc_dispatch] intermediates={:?}, ignore={:?}, byte={:02x}",
+            intermediates, ignore, byte
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,9 @@ impl Parser {
                     byte as char,
                 );
             },
-            Action::EscDispatch => performer.esc_dispatch(self.intermediates(), self.ignoring, byte),
+            Action::EscDispatch => {
+                performer.esc_dispatch(self.intermediates(), self.ignoring, byte)
+            },
             Action::Ignore | Action::None => (),
             Action::Collect => {
                 if self.intermediate_idx == MAX_INTERMEDIATES {


### PR DESCRIPTION
Since ESC escapes cannot have parameters, they have been removed from
the `esc_dispatch` function.