### PR TITLE
Fix OOB in DCS parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## [Unreleased]
+
+- Out of bounds when parsing a DCS with more than 16 parameters
+
 ## 0.7.0
 
 - Fix params reset between escapes


### PR DESCRIPTION
This resolves an issue with parsing of DCS escapes, where it would try
to write parameters beyond the maximum parameter count limit.

Fixes #50.