### PR TITLE
Process all non-ASCII bytes with the UTF-8 parser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+## 0.9.0
+
+- Remove 8-bit C1 support. 8-bit C1 codes are now interpreted as UTF-8
+  continuation bytes.
+
 ## 0.8.0
 
 - Remove C1 ST support in OSCs, fixing OSCs with ST in the payload

--- a/src/table.rs
+++ b/src/table.rs
@@ -18,15 +18,9 @@ generate_state_changes!(state_changes, {
         0x19        => (Anywhere, Execute),
         0x1c..=0x1f => (Anywhere, Execute),
         0x20..=0x7f => (Anywhere, Print),
-        0x80..=0x8f => (Anywhere, Execute),
-        0x91..=0x9a => (Anywhere, Execute),
-        0x9c        => (Anywhere, Execute),
-        // Beginning of UTF-8 2 byte sequence
-        0xc2..=0xdf => (Utf8, BeginUtf8),
-        // Beginning of UTF-8 3 byte sequence
-        0xe0..=0xef => (Utf8, BeginUtf8),
-        // Beginning of UTF-8 4 byte sequence
-        0xf0..=0xf4 => (Utf8, BeginUtf8),
+        // Hand all non-ASCII bytes to the UTF-8 parser to figure out. This
+        // includes 8-bit C1 codes, since we don't recognize them as such.
+        0x80..=0xff => (Utf8, BeginUtf8),
     },
 
     Escape {


### PR DESCRIPTION
The UTF-8 parser knows how to handle invalid byte sequences, so don't
preprocess the input in the main parser; just hand any non-ASCII byte to
the UTF-8 parser to handle.

This includes what were previously interpreted as 8-bit C1 control codes;
they are now interpreted as UTF-8 continuation characters.

This is the first in a series of patches which together fix https://github.com/alacritty/vte/issues/38 and a few related issues, in total enabling vte to process non-UTF-8 bytes in a manner consistent with Rust's `String::from_utf8_lossy`.

Removing support for the 8-bit C1 codes isn't necessary to achieve this, and I can revise this patch to restore support if desired, but removing them does simplify the table and the API. And the 8-bit C1 codes are rarely used and not well supported anyway. vte already doesn't appear to recognize 8-bit DCS, CSI, OSC, PM, or APC, Alacritty doesn't appear to intepret 8-bit NEL, SS2, or SS3, and [the remaining 8-bit C1 codes are rarely used](https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C1_control_codes_for_general_use).