### PR TITLE
Remove an obsolete reference to table.rs.in from the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,5 @@ useful with the parsed data. The `Parser` handles the book keeping, and the
 
 See the [docs] for more info.
 
-## Developer Notes
-
-If contributing to either `vte` or the `utf8parse` crate and modifying a
-_table.rs.in_ file, make sure to `cargo run` from the _codegen_ folder so that
-the compiled tables are updated.
-
 [Paul Williams' ANSI parser state machine]: https://vt100.net/emu/dec_ansi_parser
 [docs]: https://docs.rs/crate/vte/


### PR DESCRIPTION
The codegen crate and table.rs.in files were removed in
9d37aa7a71801f3569d2a2a55dc82c37935f205a and
fb2430ef10e5fc0b6b4fb73a6422abebf9bd2070.