### PR TITLE
Reduce the maximum value of CSI parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+- Changed the type of CSI parameters from i64 to u16
+
 ## 0.9.0
 
 - Added CSI subparameter support; required changes can be seen in Alacritty:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub struct Parser {
     intermediates: [u8; MAX_INTERMEDIATES],
     intermediate_idx: usize,
     params: Params,
-    param: i64,
+    param: u16,
     #[cfg(feature = "no_std")]
     osc_raw: ArrayVec<[u8; MAX_OSC_RAW]>,
     #[cfg(not(feature = "no_std"))]
@@ -334,7 +334,7 @@ impl Parser {
                 } else {
                     // Continue collecting bytes into param
                     self.param = self.param.saturating_mul(10);
-                    self.param = self.param.saturating_add((byte - b'0') as i64);
+                    self.param = self.param.saturating_add((byte - b'0') as u16);
                 }
             },
             Action::Clear => {
@@ -415,7 +415,6 @@ extern crate std;
 mod tests {
     use super::*;
 
-    use core::i64;
     use std::string::String;
     use std::vec::Vec;
 
@@ -461,7 +460,7 @@ mod tests {
     struct CsiDispatcher {
         dispatched_csi: bool,
         ignore: bool,
-        params: Vec<Vec<i64>>,
+        params: Vec<Vec<u16>>,
         intermediates: Vec<u8>,
     }
 
@@ -492,7 +491,7 @@ mod tests {
     struct DcsDispatcher {
         dispatched_dcs: bool,
         intermediates: Vec<u8>,
-        params: Vec<i64>,
+        params: Vec<u16>,
         ignore: bool,
         c: Option<char>,
         s: Vec<u8>,
@@ -732,7 +731,7 @@ mod tests {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert_eq!(dispatcher.params, &[[i64::MAX as i64]]);
+        assert_eq!(dispatcher.params, &[[u16::MAX as u16]]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,7 +731,7 @@ mod tests {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert_eq!(dispatcher.params, &[[u16::MAX as u16]]);
+        assert_eq!(dispatcher.params, &[[std::u16::MAX as u16]]);
     }
 
     #[test]

--- a/src/params.rs
+++ b/src/params.rs
@@ -15,7 +15,7 @@ pub struct Params {
     subparams: [u8; MAX_PARAMS],
 
     /// All parameters and subparameters.
-    params: [i64; MAX_PARAMS],
+    params: [u16; MAX_PARAMS],
 
     /// Number of suparameters in the current parameter.
     current_subparams: u8,
@@ -58,7 +58,7 @@ impl Params {
 
     /// Add an additional parameter.
     #[inline]
-    pub(crate) fn push(&mut self, item: i64) {
+    pub(crate) fn push(&mut self, item: u16) {
         self.subparams[self.len - self.current_subparams as usize] = self.current_subparams + 1;
         self.params[self.len] = item;
         self.current_subparams = 0;
@@ -67,7 +67,7 @@ impl Params {
 
     /// Add an additional subparameter to the current parameter.
     #[inline]
-    pub(crate) fn extend(&mut self, item: i64) {
+    pub(crate) fn extend(&mut self, item: u16) {
         self.params[self.len] = item;
         self.current_subparams += 1;
         self.len += 1;
@@ -76,7 +76,7 @@ impl Params {
 
 impl<'a> IntoIterator for &'a Params {
     type IntoIter = ParamsIter<'a>;
-    type Item = &'a [i64];
+    type Item = &'a [u16];
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -96,7 +96,7 @@ impl<'a> ParamsIter<'a> {
 }
 
 impl<'a> Iterator for ParamsIter<'a> {
-    type Item = &'a [i64];
+    type Item = &'a [u16];
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.params.len() {


### PR DESCRIPTION
Since limits CSI parameters to be within range of `u16`, rather than
`i64`. This should effectively prevent downstream users from running
into DoS problems with excessively big escape sequence requests. An
example of a problematic escape would be `CSI Ps b` (repeat char).

According to https://vt100.net/emu/dec_ansi_parser, the smallest
possible size limit would be `16383`:

> The VT500 Programmer Information is inconsistent regarding the maximum
> value that a parameter can take. In section 4.3.3.2 of EK-VT520-RM it
> says that “any parameter greater than 9999 (decimal) is set to 9999
> (decimal)”. However, in the description of DECSR (Secure Reset), its
> parameter is allowed to range from 0 to 16383. Because individual
> control functions need to make sure that numeric parameters are within
> specific limits, the supported maximum is not critical, but it must be
> at least 16383.