### PR TITLE
Fix intermediate reset when going from DCS to ESC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,323 +431,141 @@ mod tests {
     ];
 
     #[derive(Default)]
-    struct OscDispatcher {
-        dispatched_osc: bool,
-        bell_terminated: bool,
-        params: Vec<Vec<u8>>,
+    struct Dispatcher {
+        dispatched: Vec<Sequence>,
     }
 
-    // All empty bodies except osc_dispatch
-    impl Perform for OscDispatcher {
+    #[derive(Debug, PartialEq, Eq)]
+    enum Sequence {
+        Osc(Vec<Vec<u8>>, bool),
+        Csi(Vec<Vec<u16>>, Vec<u8>, bool, char),
+        Esc(Vec<u8>, bool, u8),
+        DcsHook(Vec<Vec<u16>>, Vec<u8>, bool, char),
+        DcsPut(u8),
+        DcsUnhook,
+    }
+
+    impl Perform for Dispatcher {
         fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
-            // Set a flag so we know these assertions all run
-            self.dispatched_osc = true;
-            self.bell_terminated = bell_terminated;
-            self.params = params.iter().map(|p| p.to_vec()).collect();
+            let params = params.iter().map(|p| p.to_vec()).collect();
+            self.dispatched.push(Sequence::Osc(params, bell_terminated));
         }
-    }
 
-    #[derive(Default)]
-    struct CsiDispatcher {
-        dispatched_csi: bool,
-        ignore: bool,
-        params: Vec<Vec<u16>>,
-        intermediates: Vec<u8>,
-    }
-
-    impl Perform for CsiDispatcher {
-        fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, _: char) {
-            self.intermediates = intermediates.to_vec();
-            self.dispatched_csi = true;
-            self.params = params.iter().map(|subparam| subparam.to_vec()).collect();
-            self.ignore = ignore;
+        fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: char) {
+            let params = params.iter().map(|subparam| subparam.to_vec()).collect();
+            let intermediates = intermediates.to_vec();
+            self.dispatched.push(Sequence::Csi(params, intermediates, ignore, c));
         }
-    }
 
-    #[derive(Default)]
-    struct DcsDispatcher {
-        dispatched_dcs: bool,
-        intermediates: Vec<u8>,
-        params: Vec<u16>,
-        ignore: bool,
-        c: Option<char>,
-        s: Vec<u8>,
-    }
+        fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
+            let intermediates = intermediates.to_vec();
+            self.dispatched.push(Sequence::Esc(intermediates, ignore, byte));
+        }
 
-    impl Perform for DcsDispatcher {
         fn hook(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: char) {
-            self.intermediates = intermediates.to_vec();
-            self.params = params.iter().map(|x| x.to_vec()).flatten().collect();
-            self.ignore = ignore;
-            self.c = Some(c);
-            self.dispatched_dcs = true;
+            let params = params.iter().map(|subparam| subparam.to_vec()).collect();
+            let intermediates = intermediates.to_vec();
+            self.dispatched.push(Sequence::DcsHook(params, intermediates, ignore, c));
         }
 
         fn put(&mut self, byte: u8) {
-            self.s.push(byte);
+            self.dispatched.push(Sequence::DcsPut(byte));
         }
 
         fn unhook(&mut self) {
-            self.dispatched_dcs = true;
-        }
-    }
-
-    #[derive(Default)]
-    struct EscDispatcher {
-        dispatched_esc: bool,
-        intermediates: Vec<u8>,
-        ignore: bool,
-        byte: u8,
-    }
-
-    impl Perform for EscDispatcher {
-        fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
-            self.intermediates = intermediates.to_vec();
-            self.ignore = ignore;
-            self.byte = byte;
-            self.dispatched_esc = true;
+            self.dispatched.push(Sequence::DcsUnhook);
         }
     }
 
     #[test]
     fn parse_osc() {
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in OSC_BYTES {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.dispatched_osc);
-        assert_eq!(dispatcher.params.len(), 2);
-        assert_eq!(dispatcher.params[0], &OSC_BYTES[2..3]);
-        assert_eq!(dispatcher.params[1], &OSC_BYTES[4..(OSC_BYTES.len() - 1)]);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params.len(), 2);
+                assert_eq!(params[0], &OSC_BYTES[2..3]);
+                assert_eq!(params[1], &OSC_BYTES[4..(OSC_BYTES.len() - 1)]);
+            },
+            _ => panic!("expected osc sequence"),
+        }
     }
 
     #[test]
     fn parse_empty_osc() {
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in &[0x1b, 0x5d, 0x07] {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.dispatched_osc);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(..) => (),
+            _ => panic!("expected osc sequence"),
+        }
     }
 
     #[test]
     fn parse_osc_max_params() {
         let params = std::iter::repeat(";").take(params::MAX_PARAMS + 1).collect::<String>();
         let input = format!("\x1b]{}\x1b", &params[..]).into_bytes();
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in input {
             parser.advance(&mut dispatcher, byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.dispatched_osc);
-        assert_eq!(dispatcher.params.len(), MAX_OSC_PARAMS);
-        for param in dispatcher.params.iter() {
-            assert_eq!(param.len(), 0);
-        }
-    }
-
-    #[test]
-    fn parse_dcs_max_params() {
-        let params = std::iter::repeat("1;").take(params::MAX_PARAMS + 1).collect::<String>();
-        let input = format!("\x1bP{}p", &params[..]).into_bytes();
-        let mut dispatcher = DcsDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in input {
-            parser.advance(&mut dispatcher, byte);
-        }
-
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.ignore);
-        assert!(dispatcher.dispatched_dcs);
-        assert_eq!(dispatcher.params.len(), params::MAX_PARAMS);
-        for param in dispatcher.params.iter() {
-            assert_eq!(*param, 1);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params.len(), MAX_OSC_PARAMS);
+                assert!(params.iter().all(Vec::is_empty));
+            },
+            _ => panic!("expected osc sequence"),
         }
     }
 
     #[test]
     fn osc_bell_terminated() {
         static INPUT: &[u8] = b"\x1b]11;ff/00/ff\x07";
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert!(dispatcher.dispatched_osc);
-        assert!(dispatcher.bell_terminated);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(_, true) => (),
+            _ => panic!("expected osc with bell terminator"),
+        }
     }
 
     #[test]
     fn osc_c0_st_terminated() {
         static INPUT: &[u8] = b"\x1b]11;ff/00/ff\x1b\\";
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert!(dispatcher.dispatched_osc);
-        assert!(!dispatcher.bell_terminated);
-    }
-
-    #[test]
-    fn parse_csi_max_params() {
-        // This will build a list of repeating '1;'s
-        // The length is MAX_PARAMS - 1 because the last semicolon is interpreted
-        // as an implicit zero, making the total number of parameters MAX_PARAMS
-        let params = std::iter::repeat("1;").take(params::MAX_PARAMS - 1).collect::<String>();
-        let input = format!("\x1b[{}p", &params[..]).into_bytes();
-
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in input {
-            parser.advance(&mut dispatcher, byte);
+        assert_eq!(dispatcher.dispatched.len(), 2);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(_, false) => (),
+            _ => panic!("expected osc with ST terminator"),
         }
-
-        // Check that flag is set and thus csi_dispatch assertions ran.
-        assert!(dispatcher.dispatched_csi);
-        assert_eq!(dispatcher.params.len(), params::MAX_PARAMS);
-        assert!(!dispatcher.ignore);
-    }
-
-    #[test]
-    fn parse_csi_params_ignore_long_params() {
-        // This will build a list of repeating '1;'s
-        // The length is MAX_PARAMS because the last semicolon is interpreted
-        // as an implicit zero, making the total number of parameters MAX_PARAMS + 1
-        let params = std::iter::repeat("1;").take(params::MAX_PARAMS).collect::<String>();
-        let input = format!("\x1b[{}p", &params[..]).into_bytes();
-
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in input {
-            parser.advance(&mut dispatcher, byte);
-        }
-
-        // Check that flag is set and thus csi_dispatch assertions ran.
-        assert!(dispatcher.dispatched_csi);
-        assert_eq!(dispatcher.params.len(), params::MAX_PARAMS);
-        assert!(dispatcher.ignore);
-    }
-
-    #[test]
-    fn parse_csi_params_trailing_semicolon() {
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in b"\x1b[4;m" {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert_eq!(dispatcher.params, &[[4], [0]]);
-    }
-
-    #[test]
-    fn parse_semi_set_underline() {
-        // Create dispatcher and check state
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in b"\x1b[;4m" {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert_eq!(dispatcher.params, &[[0], [4]]);
-    }
-
-    #[test]
-    fn parse_long_csi_param() {
-        // The important part is the parameter, which is (i64::MAX + 1)
-        static INPUT: &[u8] = b"\x1b[9223372036854775808m";
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert_eq!(dispatcher.params, &[[std::u16::MAX as u16]]);
-    }
-
-    #[test]
-    fn csi_reset() {
-        static INPUT: &[u8] = b"\x1b[3;1\x1b[?1049h";
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_csi);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[b'?']);
-        assert_eq!(dispatcher.params, &[[1049]]);
-    }
-
-    #[test]
-    fn csi_subparameters() {
-        static INPUT: &[u8] = b"\x1b[38:2:255:0:255;1m";
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_csi);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[]);
-        assert_eq!(dispatcher.params, &[vec![38, 2, 255, 0, 255], vec![1]]);
-    }
-
-    #[test]
-    fn dcs_reset() {
-        static INPUT: &[u8] = b"\x1b[3;1\x1bP1$tx\x9c";
-        let mut dispatcher = DcsDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_dcs);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[b'$']);
-        assert_eq!(dispatcher.params, &[1]);
-    }
-
-    #[test]
-    fn esc_reset() {
-        static INPUT: &[u8] = b"\x1b[3;1\x1b(A";
-        let mut dispatcher = EscDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_esc);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[b'(']);
     }
 
     #[test]
@@ -757,46 +575,40 @@ mod tests {
             0x5f, 0x28, 0xe3, 0x83, 0x84, 0x29, 0x5f, 0x2f, 0xc2, 0xaf, 0x27, 0x20, 0x26, 0x26,
             0x20, 0x73, 0x6c, 0x65, 0x65, 0x70, 0x20, 0x31, 0x07,
         ];
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert_eq!(dispatcher.params[0], &[b'2']);
-        assert_eq!(dispatcher.params[1], &INPUT[5..(INPUT.len() - 1)]);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params[0], &[b'2']);
+                assert_eq!(params[1], &INPUT[5..(INPUT.len() - 1)]);
+            },
+            _ => panic!("expected osc sequence"),
+        }
     }
 
     #[test]
     fn osc_containing_string_terminator() {
         static INPUT: &[u8] = b"\x1b]2;\xe6\x9c\xab\x1b\\";
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert_eq!(dispatcher.params[1], &INPUT[4..(INPUT.len() - 2)]);
-    }
-
-    #[test]
-    fn parse_dcs() {
-        static INPUT: &[u8] =
-            &[0x1b, 0x50, 0x30, 0x3b, 0x31, 0x7c, 0x31, 0x37, 0x2f, 0x61, 0x62, 0x9c];
-        let mut dispatcher = DcsDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
+        assert_eq!(dispatcher.dispatched.len(), 2);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params[1], &INPUT[4..(INPUT.len() - 2)]);
+            },
+            _ => panic!("expected osc sequence"),
         }
-
-        assert!(dispatcher.dispatched_dcs);
-        assert_eq!(dispatcher.params, vec![0, 1]);
-        assert_eq!(dispatcher.c, Some('|'));
-        assert_eq!(dispatcher.s, b"17/ab".to_vec());
     }
 
     #[test]
@@ -805,7 +617,7 @@ mod tests {
         static INPUT_START: &[u8] = &[0x1b, b']', b'5', b'2', b';', b's'];
         static INPUT_END: &[u8] = &[b'\x07'];
 
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         // Create valid OSC escape
@@ -823,16 +635,270 @@ mod tests {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert!(dispatcher.dispatched_osc);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params.len(), 2);
+                assert_eq!(params[0], b"52");
 
-        assert_eq!(dispatcher.params.len(), 2);
-        assert_eq!(dispatcher.params[0], b"52");
+                #[cfg(not(feature = "no_std"))]
+                assert_eq!(params[1].len(), NUM_BYTES + INPUT_END.len());
 
-        #[cfg(not(feature = "no_std"))]
-        assert_eq!(dispatcher.params[1].len(), NUM_BYTES + INPUT_END.len());
+                #[cfg(feature = "no_std")]
+                assert_eq!(params[1].len(), MAX_OSC_RAW - params[0].len());
+            },
+            _ => panic!("expected osc sequence"),
+        }
+    }
 
-        #[cfg(feature = "no_std")]
-        assert_eq!(dispatcher.params[1].len(), MAX_OSC_RAW - dispatcher.params[0].len());
+    #[test]
+    fn parse_csi_max_params() {
+        // This will build a list of repeating '1;'s
+        // The length is MAX_PARAMS - 1 because the last semicolon is interpreted
+        // as an implicit zero, making the total number of parameters MAX_PARAMS
+        let params = std::iter::repeat("1;").take(params::MAX_PARAMS - 1).collect::<String>();
+        let input = format!("\x1b[{}p", &params[..]).into_bytes();
+
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in input {
+            parser.advance(&mut dispatcher, byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, _, ignore, _) => {
+                assert_eq!(params.len(), params::MAX_PARAMS);
+                assert!(!ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_csi_params_ignore_long_params() {
+        // This will build a list of repeating '1;'s
+        // The length is MAX_PARAMS because the last semicolon is interpreted
+        // as an implicit zero, making the total number of parameters MAX_PARAMS + 1
+        let params = std::iter::repeat("1;").take(params::MAX_PARAMS).collect::<String>();
+        let input = format!("\x1b[{}p", &params[..]).into_bytes();
+
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in input {
+            parser.advance(&mut dispatcher, byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, _, ignore, _) => {
+                assert_eq!(params.len(), params::MAX_PARAMS);
+                assert!(ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_csi_params_trailing_semicolon() {
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in b"\x1b[4;m" {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, ..) => assert_eq!(params, &[[4], [0]]),
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_csi_params_leading_semicolon() {
+        // Create dispatcher and check state
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in b"\x1b[;4m" {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, ..) => assert_eq!(params, &[[0], [4]]),
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_long_csi_param() {
+        // The important part is the parameter, which is (i64::MAX + 1)
+        static INPUT: &[u8] = b"\x1b[9223372036854775808m";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, ..) => assert_eq!(params, &[[std::u16::MAX as u16]]),
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn csi_reset() {
+        static INPUT: &[u8] = b"\x1b[3;1\x1b[?1049h";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, intermediates, ignore, _) => {
+                assert_eq!(intermediates, &[b'?']);
+                assert_eq!(params, &[[1049]]);
+                assert!(!ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn csi_subparameters() {
+        static INPUT: &[u8] = b"\x1b[38:2:255:0:255;1m";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, intermediates, ignore, _) => {
+                assert_eq!(params, &[vec![38, 2, 255, 0, 255], vec![1]]);
+                assert_eq!(intermediates, &[]);
+                assert!(!ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_dcs_max_params() {
+        let params = std::iter::repeat("1;").take(params::MAX_PARAMS + 1).collect::<String>();
+        let input = format!("\x1bP{}p", &params[..]).into_bytes();
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in input {
+            parser.advance(&mut dispatcher, byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::DcsHook(params, _, ignore, _) => {
+                assert_eq!(params.len(), params::MAX_PARAMS);
+                assert!(params.iter().all(|param| param == &[1]));
+                assert!(ignore);
+            },
+            _ => panic!("expected dcs sequence"),
+        }
+    }
+
+    #[test]
+    fn dcs_reset() {
+        static INPUT: &[u8] = b"\x1b[3;1\x1bP1$tx\x9c";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 3);
+        match &dispatcher.dispatched[0] {
+            Sequence::DcsHook(params, intermediates, ignore, _) => {
+                assert_eq!(intermediates, &[b'$']);
+                assert_eq!(params, &[[1]]);
+                assert!(!ignore);
+            },
+            _ => panic!("expected dcs sequence"),
+        }
+        assert_eq!(dispatcher.dispatched[1], Sequence::DcsPut(b'x'));
+        assert_eq!(dispatcher.dispatched[2], Sequence::DcsUnhook);
+    }
+
+    #[test]
+    fn parse_dcs() {
+        static INPUT: &[u8] = b"\x1bP0;1|17/ab\x9c";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 7);
+        match &dispatcher.dispatched[0] {
+            Sequence::DcsHook(params, _, _, c) => {
+                assert_eq!(params, &[[0], [1]]);
+                assert_eq!(c, &'|');
+            },
+            _ => panic!("expected dcs sequence"),
+        }
+        for (i, byte) in b"17/ab".iter().enumerate() {
+            assert_eq!(dispatcher.dispatched[1 + i], Sequence::DcsPut(*byte));
+        }
+        assert_eq!(dispatcher.dispatched[6], Sequence::DcsUnhook);
+    }
+
+    #[test]
+    fn intermediate_reset_on_dcs_exit() {
+        static INPUT: &[u8] = b"\x1bP=1sZZZ\x1b+\x5c";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 6);
+        match &dispatcher.dispatched[5] {
+            Sequence::Esc(intermediates, ..) => assert_eq!(intermediates, &[b'+']),
+            _ => panic!("expected esc sequence"),
+        }
+    }
+
+    #[test]
+    fn esc_reset() {
+        static INPUT: &[u8] = b"\x1b[3;1\x1b(A";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Esc(intermediates, ignore, byte) => {
+                assert_eq!(intermediates, &[b'(']);
+                assert_eq!(*byte, b'A');
+                assert!(!ignore);
+            },
+            _ => panic!("expected esc sequence"),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,28 +165,26 @@ impl Parser {
                 match self.state {
                     State::DcsPassthrough => {
                         self.perform_action(performer, Action::Unhook, byte);
-                        maybe_action!(action, byte);
                     },
                     State::OscString => {
                         self.perform_action(performer, Action::OscEnd, byte);
-                        maybe_action!(action, byte);
                     },
-                    _ => {
-                        maybe_action!(action, byte);
+                    _ => (),
+                }
 
-                        match state {
-                            State::CsiEntry | State::DcsEntry | State::Escape => {
-                                self.perform_action(performer, Action::Clear, byte);
-                            },
-                            State::DcsPassthrough => {
-                                self.perform_action(performer, Action::Hook, byte);
-                            },
-                            State::OscString => {
-                                self.perform_action(performer, Action::OscStart, byte);
-                            },
-                            _ => (),
-                        }
+                maybe_action!(action, byte);
+
+                match state {
+                    State::CsiEntry | State::DcsEntry | State::Escape => {
+                        self.perform_action(performer, Action::Clear, byte);
                     },
+                    State::DcsPassthrough => {
+                        self.perform_action(performer, Action::Hook, byte);
+                    },
+                    State::OscString => {
+                        self.perform_action(performer, Action::OscStart, byte);
+                    },
+                    _ => (),
                 }
 
                 // Assume the new state


### PR DESCRIPTION
This resolves a bug when transitioning between DCS and ESC sequences,
which would cause the intermediates of the ESC dispatch to contain data
from the DCS sequence.