### PR TITLE
Use repr(u8) on State/Action

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -2,6 +2,7 @@ use core::mem;
 
 #[allow(dead_code)]
 #[derive(Debug, Copy, Clone)]
+#[repr(u8)]
 pub enum State {
     Anywhere = 0,
     CsiEntry = 1,
@@ -29,6 +30,7 @@ impl Default for State {
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
+#[repr(u8)]
 pub enum Action {
     None = 0,
     Clear = 1,


### PR DESCRIPTION
Right now they'd be repr(Rust), which isn't guaranteed. If that repr changed (for example under a hypothetical `-Z repr-rust-layout=randomize`, which has been discussed), this code would fail to compile (the transmute later requires u8).