### PR TITLE
Fix filled params list ending with subparam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## Unreleased
 
 - Minimum rust version has been bumped to 1.56.0
+- Fixed infinite loop in `Params` iterator when 32nd parameter is a subparameter
 
 ## 0.10.1
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -68,6 +68,7 @@ impl Params {
     /// Add an additional subparameter to the current parameter.
     #[inline]
     pub(crate) fn extend(&mut self, item: u16) {
+        self.subparams[self.len - self.current_subparams as usize] = self.current_subparams + 1;
         self.params[self.len] = item;
         self.current_subparams += 1;
         self.len += 1;


### PR DESCRIPTION
When the params list for the CSI/DCS escapes is filled with all 32
parameters but ends in a subparameter, it would not properly stage the
length of the added subparameters causing the param iterator to get
stuck in place.

To ensure we always update the subparameter length even when no
parameter is staged after it, the length of subparameters is now updated
immediately while the subparameters itself are added.

Fixes #77.