### PR TITLE
Upgrade to arrayvec v0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 vte_generate_state_changes = { version = "0.1.0", path = "vte_generate_state_changes" }
-arrayvec = { version = "0.5.1", default-features = false, optional = true }
+arrayvec = { version = "0.7.2", default-features = false, optional = true }
 utf8parse = { version = "0.2.0", path = "utf8parse" }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub struct Parser {
     params: Params,
     param: u16,
     #[cfg(feature = "no_std")]
-    osc_raw: ArrayVec<[u8; MAX_OSC_RAW]>,
+    osc_raw: ArrayVec<u8, MAX_OSC_RAW>,
     #[cfg(not(feature = "no_std"))]
     osc_raw: Vec<u8>,
     osc_params: [(usize, usize); MAX_OSC_PARAMS],


### PR DESCRIPTION
Hey @alacritty! This would be a big help in getting a duplicate copy of arrayvec out of our tree at @MaterializeInc.