### PR TITLE
Add trivial derives to `utf8parser::Parser`

### DIFF
--- a/utf8parse/src/lib.rs
+++ b/utf8parse/src/lib.rs
@@ -25,7 +25,7 @@ pub trait Receiver {
 /// A parser for Utf8 Characters
 ///
 /// Repeatedly call `advance` with bytes to emit Utf8 characters
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Parser {
     point: u32,
     state: State,

--- a/utf8parse/src/lib.rs
+++ b/utf8parse/src/lib.rs
@@ -25,7 +25,7 @@ pub trait Receiver {
 /// A parser for Utf8 Characters
 ///
 /// Repeatedly call `advance` with bytes to emit Utf8 characters
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct Parser {
     point: u32,
     state: State,

--- a/utf8parse/src/types.rs
+++ b/utf8parse/src/types.rs
@@ -26,7 +26,7 @@ pub enum Action {
 /// There is a state for each initial input of the 3 and 4 byte sequences since
 /// the following bytes are subject to different conditions than a tail byte.
 #[allow(non_camel_case_types)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum State {
     /// Ground state; expect anything
     Ground = 0,


### PR DESCRIPTION
I am using this to validate output sent to `std::io::Write::write` but the entire validated output might not be written.  To workaround this, I need to snapshot my validation state, attempt the `write`, and then replay my validation up-to what was written.  This requires the data to be `clone`able to do so but `Parser` isn't.

Much like `std::ops::Range`, we likely don't want this to be `Copy` as that makes it too easy to get mixed up on what state you are using but `Clone` should be explicit enough to be safe.

In addition to `Clone`, I've also added `Debug`, `PartialEq`, and `Eq`