### PR TITLE
migrate `ansi` from `alacritty_terminal`

### DIFF
--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -16,8 +16,8 @@ tasks:
       $HOME/.cargo/bin/rustup toolchain install nightly -c rustfmt
       cd vte
       $HOME/.cargo/bin/cargo +nightly fmt -- --check
-  - 1-56-0: |
-      $HOME/.cargo/bin/rustup toolchain install --profile minimal 1.56.0
+  - 1-62-1: |
+      $HOME/.cargo/bin/rustup toolchain install --profile minimal 1.62.1
       cd vte
       rm Cargo.lock
-      $HOME/.cargo/bin/cargo +1.56.0 test
+      $HOME/.cargo/bin/cargo +1.62.1 test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+- Minimum rust version has been bumped to 1.62.1
+- Support for ANSI terminal stream parsing under the `ansi` feature.
+- Addition of the `serde` feature which additionally derives `Serialize` and `Deserialize` 
+  for the types provided in the `ansi` module.
+
 ## 0.11.0
 
 - Minimum rust version has been bumped to 1.56.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 
 - Minimum rust version has been bumped to 1.62.1
 - Support for ANSI terminal stream parsing under the `ansi` feature.
-- Addition of the `serde` feature which additionally derives `Serialize` and `Deserialize` 
+- Addition of the `serde` feature which derives `Serialize` and `Deserialize`
   for the types provided in the `ansi` module.
 
 ## 0.11.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,11 @@ vte_generate_state_changes = { version = "0.1.0", path = "vte_generate_state_cha
 arrayvec = { version = "0.7.2", default-features = false, optional = true }
 log = { version = "0.4.17", optional = true }
 utf8parse = { version = "0.2.0", path = "utf8parse" }
+serde = { version = "1.0.160", features = ["derive"], optional = true }
 
 [features]
 ansi = ["log"]
+ansi-serde = ["serde"]
 default = ["no_std"]
 no_std = ["arrayvec"]
 nightly = ["utf8parse/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.56.0"
 [dependencies]
 vte_generate_state_changes = { version = "0.1.0", path = "vte_generate_state_changes" }
 arrayvec = { version = "0.7.2", default-features = false, optional = true }
-log = { version = "0.4", optional = true }
+log = { version = "0.4.17", optional = true }
 utf8parse = { version = "0.2.0", path = "utf8parse" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.160", features = ["derive"], optional = true }
 
 [features]
 ansi = ["log"]
-ansi-serde = ["serde"]
+serde = ["dep:serde"]
 default = ["no_std"]
 no_std = ["arrayvec"]
 nightly = ["utf8parse/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.160", features = ["derive"], optional = true }
 ansi = ["log"]
 serde = ["dep:serde"]
 default = ["no_std"]
+floats = []
 no_std = ["arrayvec"]
 nightly = ["utf8parse/nightly"]
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,5 +1,7 @@
 //! ANSI Terminal Stream Parsing.
 
+extern crate alloc;
+
 use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -455,14 +455,21 @@ impl Timeout for StdSyncHandler {
     }
 }
 
+/// Provides an interface for common timer functionality (i.e.
+/// creating timeouts and checking if it has been expired).
+///
+/// This is internally used by the [`Processor`] to handle synchronized
+/// updates.
 pub trait Timeout: Default {
     /// Sets the timeout for the next synchronized update.
     ///
-    /// The `duration` parameter specifies the duration of the timeout. Once the timeout has elapsed, the synchronized update can be performed.
+    /// The `duration` parameter specifies the duration of the timeout. Once the
+    /// specified duration has elapsed, the synchronized update rotuine can be
+    /// performed.
     fn set_timeout(&mut self, duration: Duration);
     /// Clear the current timeout.
     fn clear_timeout(&mut self);
-    /// Returns whether a timeout is currently pending.
+    /// Returns whether a timeout is currently active and has not yet expired.
     fn pending_timeout(&self) -> bool;
 }
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -20,7 +20,6 @@ use core::time::Duration;
 use core::{iter, str};
 
 use log::{debug, trace};
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -456,9 +456,9 @@ impl Timeout for StdSyncHandler {
 }
 
 pub trait Timeout: Default {
-    /// Sets the timeout for the next synchronized update. The `duration` parameter
-    /// specifies the duration of the timeout. Once the timeout has elapsed, the
-    /// synchronized update can be performed.
+    /// Sets the timeout for the next synchronized update.
+    ///
+    /// The `duration` parameter specifies the duration of the timeout. Once the timeout has elapsed, the synchronized update can be performed.
     fn set_timeout(&mut self, duration: Duration);
     /// Clear the current timeout.
     fn clear_timeout(&mut self);

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -319,11 +319,11 @@ impl<T: SyncHandler> Processor<T> {
     where
         H: Handler,
     {
-        if !self.state.sync_state.handler.pending_timeout() {
+        if self.state.sync_state.handler.pending_timeout() {
+            self.advance_sync(handler, byte);
+        } else {
             let mut performer = Performer::new(&mut self.state, handler);
             self.parser.advance(&mut performer, byte);
-        } else {
-            self.advance_sync(handler, byte);
         }
     }
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -22,6 +22,9 @@ use core::{iter, str};
 #[cfg(feature = "floats")]
 use core::ops::Mul;
 
+#[cfg(not(feature = "no_std"))]
+use std::time::Instant;
+
 use log::{debug, trace};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -422,14 +425,14 @@ impl<'a, H: Handler + 'a, T: SyncHandler> Performer<'a, H, T> {
 #[cfg(not(feature = "no_std"))]
 #[derive(Default)]
 pub struct StdSyncHandler {
-    timeout: Option<std::time::Instant>,
+    timeout: Option<Instant>,
 }
 
 #[cfg(not(feature = "no_std"))]
 impl StdSyncHandler {
     /// Synchronized update expiration time.
     #[inline]
-    pub fn sync_timeout(&self) -> Option<std::time::Instant> {
+    pub fn sync_timeout(&self) -> Option<Instant> {
         self.timeout
     }
 }
@@ -437,7 +440,6 @@ impl StdSyncHandler {
 #[cfg(not(feature = "no_std"))]
 impl SyncHandler for StdSyncHandler {
     fn update_timeout(&mut self, duration: Option<Duration>) {
-        use std::time::Instant;
         self.timeout = duration.map(|e| Instant::now() + e);
     }
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -13,8 +13,9 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use core::convert::TryFrom;
-use core::fmt::Write;
+use core::fmt::{self, Display, Formatter, Write};
 use core::ops::{Add, Mul, Sub};
+use core::str::FromStr;
 use core::time::Duration;
 use core::{iter, str};
 
@@ -115,6 +116,38 @@ impl Sub<Rgb> for Rgb {
             r: self.r.saturating_sub(rhs.r),
             g: self.g.saturating_sub(rhs.g),
             b: self.b.saturating_sub(rhs.b),
+        }
+    }
+}
+
+impl Display for Rgb {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "#{:02x}{:02x}{:02x}", self.r, self.g, self.b)
+    }
+}
+
+impl FromStr for Rgb {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Rgb, ()> {
+        let chars = if s.starts_with("0x") && s.len() == 8 {
+            &s[2..]
+        } else if s.starts_with('#') && s.len() == 7 {
+            &s[1..]
+        } else {
+            return Err(());
+        };
+
+        match u32::from_str_radix(chars, 16) {
+            Ok(mut color) => {
+                let b = (color & 0xff) as u8;
+                color >>= 8;
+                let g = (color & 0xff) as u8;
+                color >>= 8;
+                let r = color as u8;
+                Ok(Rgb { r, g, b })
+            },
+            Err(_) => Err(()),
         }
     }
 }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -14,7 +14,7 @@ use alloc::vec::Vec;
 
 use core::convert::TryFrom;
 use core::fmt::{self, Display, Formatter, Write};
-use core::ops::{Add, Mul, Sub};
+use core::ops::{Add, Sub};
 use core::str::FromStr;
 use core::time::Duration;
 use core::{iter, str};
@@ -46,6 +46,7 @@ impl Rgb {
     /// Implementation of [W3C's luminance algorithm].
     ///
     /// [W3C's luminance algorithm]: https://www.w3.org/TR/WCAG20/#relativeluminancedef
+    #[cfg(feature = "floats")]
     pub fn luminance(self) -> f64 {
         let channel_luminance = |channel| {
             let channel = channel as f64 / 255.;
@@ -66,6 +67,7 @@ impl Rgb {
     /// Implementation of [W3C's contrast algorithm].
     ///
     /// [W3C's contrast algorithm]: https://www.w3.org/TR/WCAG20/#contrast-ratiodef
+    #[cfg(feature = "floats")]
     pub fn contrast(self, other: Rgb) -> f64 {
         let self_luminance = self.luminance();
         let other_luminance = other.luminance();
@@ -81,7 +83,8 @@ impl Rgb {
 }
 
 // A multiply function for Rgb, as the default dim is just *2/3.
-impl Mul<f32> for Rgb {
+#[cfg(feature = "floats")]
+impl core::ops::Mul<f32> for Rgb {
     type Output = Rgb;
 
     fn mul(self, rhs: f32) -> Rgb {

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -455,8 +455,7 @@ impl Timeout for StdSyncHandler {
     }
 }
 
-/// Provides an interface for common timer functionality (i.e.
-/// creating timeouts and checking if it has been expired).
+/// Interface for creating timeouts and checking their expiry.
 ///
 /// This is internally used by the [`Processor`] to handle synchronized
 /// updates.

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// This module was originally part of the `alacritty_terminal` crate, which is
+// licensed under the Apache License, Version 2.0 and is part of the Alacritty
+// project (https://github.com/alacritty/alacritty).
+
 //! ANSI Terminal Stream Parsing.
 
 extern crate alloc;

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -287,7 +287,7 @@ enum Dcs {
 /// The processor wraps a `crate::Parser` to ultimately call methods on a Handler.
 #[cfg(not(feature = "no_std"))]
 #[derive(Default)]
-pub struct Processor<T: SyncHandler = DefaultSyncHandler> {
+pub struct Processor<T: SyncHandler = StdSyncHandler> {
     state: ProcessorState<T>,
     parser: crate::Parser,
 }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -19,7 +19,7 @@ use core::{iter, str};
 
 use log::{debug, trace};
 
-#[cfg(feature = "ansi-serde")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{Params, ParamsIter};
@@ -85,7 +85,7 @@ pub struct Hyperlink {
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
-#[cfg_attr(feature = "ansi-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rgb {
     pub r: u8,
     pub g: u8,
@@ -718,7 +718,7 @@ pub enum TabulationClearMode {
 /// The order here matters since the enum should be castable to a `usize` for
 /// indexing a color list.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "ansi-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NamedColor {
     /// Black.
     Black = 0,
@@ -833,7 +833,7 @@ impl NamedColor {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "ansi-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Color {
     Named(NamedColor),
     Spec(Rgb),

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -19,7 +19,7 @@ use core::str::FromStr;
 use core::time::Duration;
 use core::{iter, str};
 
-#[cfg(feature = "floats")]
+#[cfg(not(feature = "no_std"))]
 use core::ops::Mul;
 
 #[cfg(not(feature = "no_std"))]
@@ -66,7 +66,7 @@ impl Rgb {
     /// Implementation of [W3C's luminance algorithm].
     ///
     /// [W3C's luminance algorithm]: https://www.w3.org/TR/WCAG20/#relativeluminancedef
-    #[cfg(feature = "floats")]
+    #[cfg(not(feature = "no_std"))]
     pub fn luminance(self) -> f64 {
         let channel_luminance = |channel| {
             let channel = channel as f64 / 255.;
@@ -87,7 +87,7 @@ impl Rgb {
     /// Implementation of [W3C's contrast algorithm].
     ///
     /// [W3C's contrast algorithm]: https://www.w3.org/TR/WCAG20/#contrast-ratiodef
-    #[cfg(feature = "floats")]
+    #[cfg(not(feature = "no_std"))]
     pub fn contrast(self, other: Rgb) -> f64 {
         let self_luminance = self.luminance();
         let other_luminance = other.luminance();
@@ -103,7 +103,7 @@ impl Rgb {
 }
 
 // A multiply function for Rgb, as the default dim is just *2/3.
-#[cfg(feature = "floats")]
+#[cfg(not(feature = "no_std"))]
 impl Mul<f32> for Rgb {
     type Output = Rgb;
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -11,6 +11,9 @@ use core::{iter, str};
 
 use log::{debug, trace};
 
+#[cfg(feature = "ansi-serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{Params, ParamsIter};
 
 pub trait SyncHandler: Default {
@@ -64,6 +67,7 @@ pub struct Hyperlink {
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
+#[cfg_attr(feature = "ansi-serde", derive(Serialize, Deserialize))]
 pub struct Rgb {
     pub r: u8,
     pub g: u8,
@@ -691,6 +695,7 @@ pub enum TabulationClearMode {
 /// The order here matters since the enum should be castable to a `usize` for
 /// indexing a color list.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "ansi-serde", derive(Serialize, Deserialize))]
 pub enum NamedColor {
     /// Black.
     Black = 0,
@@ -805,6 +810,7 @@ impl NamedColor {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "ansi-serde", derive(Serialize, Deserialize))]
 pub enum Color {
     Named(NamedColor),
     Spec(Rgb),

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -1,7 +1,7 @@
 use core::mem;
 
 #[allow(dead_code)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub enum State {
     Anywhere = 0,
     CsiEntry = 1,
@@ -15,16 +15,11 @@ pub enum State {
     DcsPassthrough = 9,
     Escape = 10,
     EscapeIntermediate = 11,
+    #[default]
     Ground = 12,
     OscString = 13,
     SosPmApcString = 14,
     Utf8 = 15,
-}
-
-impl Default for State {
-    fn default() -> State {
-        State::Ground
-    }
 }
 
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 #![cfg_attr(feature = "no_std", no_std)]
 
-extern crate alloc;
-
 use core::mem::MaybeUninit;
 
 #[cfg(feature = "no_std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 #![cfg_attr(feature = "no_std", no_std)]
 
+extern crate alloc;
+
 use core::mem::MaybeUninit;
 
 #[cfg(feature = "no_std")]

--- a/utf8parse/src/types.rs
+++ b/utf8parse/src/types.rs
@@ -26,9 +26,10 @@ pub enum Action {
 /// There is a state for each initial input of the 3 and 4 byte sequences since
 /// the following bytes are subject to different conditions than a tail byte.
 #[allow(non_camel_case_types)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub enum State {
     /// Ground state; expect anything
+    #[default]
     Ground = 0,
     /// 3 tail bytes
     Tail3 = 1,
@@ -44,12 +45,6 @@ pub enum State {
     Utf8_4_3_f0 = 6,
     /// UTF8-4 starting with F4
     Utf8_4_3_f4 = 7,
-}
-
-impl Default for State {
-    fn default() -> State {
-        State::Ground
-    }
 }
 
 impl State {


### PR DESCRIPTION
This pull request is a continuation of https://github.com/alacritty/vte/pull/64 rather than https://github.com/alacritty/vte/pull/75 (which additionally added `no-alloc` support). If required, `no-alloc` support can be added in a follow up pull request.

## Unresolved Questions
* Should the `log` crate be used? It should be fine to ignore stuff that is unhanded. 