### PR TITLE
ansi: add tests for `Rgb::contrast`

### DIFF
--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -8,6 +8,7 @@ tasks:
       cd vte
       $HOME/.cargo/bin/cargo +stable test
       $HOME/.cargo/bin/cargo +stable test --features=ansi
+      $HOME/.cargo/bin/cargo +stable test --features=ansi --no-default-features
   - clippy: |
       cd vte
       $HOME/.cargo/bin/cargo +stable clippy

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -2085,4 +2085,23 @@ mod tests {
         let expected: Vec<usize> = (0..256).collect();
         assert_eq!(handler.reset_colors, expected);
     }
+
+    #[test]
+    #[cfg(not(feature = "no_std"))]
+    fn contrast() {
+        let rgb1 = Rgb { r: 0xff, g: 0xff, b: 0xff };
+        let rgb2 = Rgb { r: 0x00, g: 0x00, b: 0x00 };
+        assert!((rgb1.contrast(rgb2) - 21.).abs() < f64::EPSILON);
+
+        let rgb1 = Rgb { r: 0xff, g: 0xff, b: 0xff };
+        assert!((rgb1.contrast(rgb1) - 1.).abs() < f64::EPSILON);
+
+        let rgb1 = Rgb { r: 0xff, g: 0x00, b: 0xff };
+        let rgb2 = Rgb { r: 0x00, g: 0xff, b: 0x00 };
+        assert!((rgb1.contrast(rgb2) - 2.285_543_608_124_253_3).abs() < f64::EPSILON);
+
+        let rgb1 = Rgb { r: 0x12, g: 0x34, b: 0x56 };
+        let rgb2 = Rgb { r: 0xfe, g: 0xdc, b: 0xba };
+        assert!((rgb1.contrast(rgb2) - 9.786_558_997_257_74).abs() < f64::EPSILON);
+    }
 }


### PR DESCRIPTION
These test cases have been migrated from `alacritty/alacritty_terminal/src/term/color.rs`.