### PR TITLE
Bump rust-version to match actual MSRV

### DIFF
--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -17,8 +17,9 @@ tasks:
       $HOME/.cargo/bin/rustup toolchain install nightly -c rustfmt
       cd vte
       $HOME/.cargo/bin/cargo +nightly fmt -- --check
-  - 1-62-1: |
-      $HOME/.cargo/bin/rustup toolchain install --profile minimal 1.62.1
+  - msrv: |
       cd vte
+      msrv=$(cat Cargo.toml | grep "rust-version" | sed 's/.*"\(.*\)".*/\1/')
+      $HOME/.cargo/bin/rustup toolchain install --profile minimal $msrv
       rm Cargo.lock
-      $HOME/.cargo/bin/cargo +1.62.1 test
+      $HOME/.cargo/bin/cargo +$msrv test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 version = "0.11.1"
 name = "vte"
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.62.1"
 
 [dependencies]
 vte_generate_state_changes = { version = "0.1.0", path = "vte_generate_state_changes" }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -678,9 +678,10 @@ pub struct CursorStyle {
 }
 
 /// Terminal cursor shape.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+#[derive(Debug, Default, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum CursorShape {
     /// Cursor is a block like `▒`.
+    #[default]
     Block,
 
     /// Cursor is an underscore like `_`.
@@ -694,12 +695,6 @@ pub enum CursorShape {
 
     /// Invisible cursor.
     Hidden,
-}
-
-impl Default for CursorShape {
-    fn default() -> CursorShape {
-        CursorShape::Block
-    }
 }
 
 /// Terminal modes.
@@ -1023,32 +1018,22 @@ pub enum Attr {
 }
 
 /// Identifiers which can be assigned to a graphic character set.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum CharsetIndex {
     /// Default set, is designated as ASCII at startup.
+    #[default]
     G0,
     G1,
     G2,
     G3,
 }
 
-impl Default for CharsetIndex {
-    fn default() -> Self {
-        CharsetIndex::G0
-    }
-}
-
 /// Standard or common character sets which can be designated as G0-G3.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum StandardCharset {
+    #[default]
     Ascii,
     SpecialCharacterAndLineDrawing,
-}
-
-impl Default for StandardCharset {
-    fn default() -> Self {
-        StandardCharset::Ascii
-    }
 }
 
 impl StandardCharset {


### PR DESCRIPTION
#85 bumped the MSRV but failed to bump the `rust-version` in `Cargo.toml`.