### PR TITLE
Allow no-std users to control the size of the osc_raw buffer.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ use definitions::{unpack, Action, State};
 
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_PARAMS: usize = 16;
-#[cfg(any(feature = "no_std", test))]
 const MAX_OSC_RAW: usize = 1024;
 
 struct VtUtf8Receiver<'a, P: Perform>(&'a mut P, &'a mut State);
@@ -72,15 +71,19 @@ impl<'a, P: Perform> utf8::Receiver for VtUtf8Receiver<'a, P> {
 /// Parser for raw _VTE_ protocol which delegates actions to a [`Perform`]
 ///
 /// [`Perform`]: trait.Perform.html
+///
+/// Generic over the value for the size of the raw Operating System Command
+/// buffer, but that only has an effect in when the `no_std` feature is enabled
+/// and can be ignored otherwise.
 #[derive(Default)]
-pub struct Parser {
+pub struct Parser<const OSC_RAW_BUF_SIZE: usize = MAX_OSC_RAW> {
     state: State,
     intermediates: [u8; MAX_INTERMEDIATES],
     intermediate_idx: usize,
     params: Params,
     param: u16,
     #[cfg(feature = "no_std")]
-    osc_raw: ArrayVec<u8, MAX_OSC_RAW>,
+    osc_raw: ArrayVec<u8, OSC_RAW_BUF_SIZE>,
     #[cfg(not(feature = "no_std"))]
     osc_raw: Vec<u8>,
     osc_params: [(usize, usize); MAX_OSC_PARAMS],
@@ -92,7 +95,21 @@ pub struct Parser {
 impl Parser {
     /// Create a new Parser
     pub fn new() -> Parser {
-        Parser::default()
+        Default::default()
+    }
+}
+
+impl<const OSC_RAW_BUF_SIZE: usize> Parser<OSC_RAW_BUF_SIZE> {
+    /// Create a new Parser with a custom size for the Operating System Command buffer.
+    ///
+    /// Call with a const-generic param on `Parser`, like:
+    ///
+    /// ```rust
+    /// let mut p = vte::Parser::<64>::new_with_size();
+    /// ```
+    #[cfg(feature = "no_std")]
+    pub fn new_with_size() -> Parser<OSC_RAW_BUF_SIZE> {
+        Default::default()
     }
 
     #[inline]
@@ -919,6 +936,28 @@ mod tests {
                 assert_eq!(params, &[[0; 32]]);
                 assert_eq!(c, &'x');
                 assert!(ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[cfg(feature = "no_std")]
+    #[test]
+    fn build_with_fixed_size() {
+        static INPUT: &[u8] = b"\x1b[3;1\x1b[?1049h";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser: Parser<30> = Parser::new_with_size();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, intermediates, ignore, _) => {
+                assert_eq!(intermediates, &[b'?']);
+                assert_eq!(params, &[[1049]]);
+                assert!(!ignore);
             },
             _ => panic!("expected csi sequence"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,7 @@ impl<'a, P: Perform> utf8::Receiver for VtUtf8Receiver<'a, P> {
 /// [`Perform`]: trait.Perform.html
 ///
 /// Generic over the value for the size of the raw Operating System Command
-/// buffer, but that only has an effect in when the `no_std` feature is enabled
-/// and can be ignored otherwise.
+/// buffer. Only used when the `no_std` feature is enabled.
 #[derive(Default)]
 pub struct Parser<const OSC_RAW_BUF_SIZE: usize = MAX_OSC_RAW> {
     state: State,


### PR DESCRIPTION
It was set to 1024 bytes, which is a lot if you don't care about parsing Operating System Command sequences. Now you can set it to a custom size.

Closes #90 