### PR TITLE
Split `Mode` into `Public` and `Private`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 ## Unreleased
 
 - Reexport `cursor_icon` crate in `ansi`
+- Split `set_mode` into `set_private_mode` and `set_public_mode`
+- Split `unset_mode` into `unset_private_mode` and `unset_public_mode`
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 ## Unreleased
 
 - Reexport `cursor_icon` crate in `ansi`
-- Split `set_mode` into `set_private_mode` and `set_public_mode`
-- Split `unset_mode` into `unset_private_mode` and `unset_public_mode`
+- Split-out private modes from `Mode` into `PrivateMode`
+- Add `unset_private_mode` and `set_private_mode`
 
 ## 0.12.0
 


### PR DESCRIPTION
The modes could overlap and there's also no way to actually forward information about unhandled modes downstream, thus split the modes into 2 separate structures and pass unhandled modes.