### PR TITLE
Bump crate versions missing license files

### DIFF
--- a/utf8parse/Cargo.toml
+++ b/utf8parse/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/alacritty/vte"
 keywords = ["utf8", "parse", "table"]
 categories = ["parsing", "no-std"]
 license = "Apache-2.0 OR MIT"
-version = "0.2.1"
+version = "0.2.2"
 name = "utf8parse"
 edition = "2018"
 

--- a/vte_generate_state_changes/Cargo.toml
+++ b/vte_generate_state_changes/Cargo.toml
@@ -4,7 +4,7 @@ description = "Proc macro for generating VTE state changes"
 repository = "https://github.com/alacritty/vte"
 name = "vte_generate_state_changes"
 license = "Apache-2.0 OR MIT"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 
 [lib]


### PR DESCRIPTION
This patch bumps utf8parse/vte_generate_state_changes versions to release the change which included the license files into the crates.io package.

Closes #113.

---

One commit to bump two crates, but I think it should be fine. Will tag separately.