### PR TITLE
Add support for custom parsing of APC, SOS and PM sequences.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,36 +864,35 @@ pub trait Perform {
     /// encountered.
     fn sos_start(&mut self) {}
 
-    /// Invoked when the beginning of a new APC (Application Program Command)
-    /// sequence is encountered.
-    fn apc_start(&mut self) {}
+    /// Invoked for every valid byte (0x20-0xFF) in a SOS (Start of String)
+    /// sequence.
+    fn sos_put(&mut self, _byte: u8) {}
+
+    /// Invoked when the end of an SOS (Start of String) sequence is
+    /// encountered.
+    fn sos_end(&mut self) {}
 
     /// Invoked when the beginning of a new PM (Privacy Message) sequence is
     /// encountered.
     fn pm_start(&mut self) {}
 
-    /// Invoked for every valid character (0x20-0xFF) in a SOS (Start of String)
+    /// Invoked for every valid byte (0x20-0xFF) in a PM (Privacy Message)
     /// sequence.
-    fn sos_dispatch(&mut self, _byte: u8) {}
-
-    /// Invoked for every valid character (0x20-0xFF) in an APC (Application
-    /// Program Command) sequence.
-    fn apc_dispatch(&mut self, _byte: u8) {}
-
-    /// Invoked for every valid character (0x20-0xFF) in a PM (Privacy Message)
-    /// sequence.
-    fn pm_dispatch(&mut self, _byte: u8) {}
-
-    /// Invoked when the end of an SOS (Start of String) sequence is
-    /// encountered.
-    fn sos_string_end(&mut self) {}
-
-    /// Invoked when the end of an APC (Application Program Command) sequence is
-    /// encountered.
-    fn apc_string_end(&mut self) {}
+    fn pm_put(&mut self, _byte: u8) {}
 
     /// Invoked when the end of a PM (Privacy Message) sequence is encountered.
-    fn pm_string_end(&mut self) {}
+    fn pm_end(&mut self) {}
+
+    /// Invoked when the beginning of a new APC (Application Program Command)
+    /// sequence is encountered.
+    fn apc_start(&mut self) {}
+
+    /// Invoked for every valid byte (0x20-0xFF) in an APC (Application Program
+    /// Command) sequence.
+    fn apc_put(&mut self, _byte: u8) {}
+    /// Invoked when the end of an APC (Application Program Command) sequence is
+    /// encountered.
+    fn apc_end(&mut self) {}
 
     /// Whether the parser should terminate prematurely.
     ///
@@ -925,12 +924,12 @@ impl<P: Perform> OpaqueDispatch for SosDispatch<'_, P> {
 
     #[inline(always)]
     fn opaque_put(&mut self, byte: u8) {
-        self.0.sos_dispatch(byte);
+        self.0.sos_put(byte);
     }
 
     #[inline(always)]
     fn opaque_end(&mut self) {
-        self.0.sos_string_end();
+        self.0.sos_end();
     }
 }
 
@@ -944,12 +943,12 @@ impl<P: Perform> OpaqueDispatch for ApcDispatch<'_, P> {
 
     #[inline(always)]
     fn opaque_put(&mut self, byte: u8) {
-        self.0.apc_dispatch(byte);
+        self.0.apc_put(byte);
     }
 
     #[inline(always)]
     fn opaque_end(&mut self) {
-        self.0.apc_string_end();
+        self.0.apc_end();
     }
 }
 
@@ -963,12 +962,12 @@ impl<P: Perform> OpaqueDispatch for PmDispatch<'_, P> {
 
     #[inline(always)]
     fn opaque_put(&mut self, byte: u8) {
-        self.0.pm_dispatch(byte);
+        self.0.pm_put(byte);
     }
 
     #[inline(always)]
     fn opaque_end(&mut self) {
-        self.0.pm_string_end();
+        self.0.pm_end();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,10 +359,8 @@ impl<const OSC_RAW_BUF_SIZE: usize> Parser<OSC_RAW_BUF_SIZE> {
                 self.state = State::Ground
             },
             0x58 => {
-                self.state = {
-                    performer.sos_start();
-                    State::SosString
-                }
+                performer.sos_start();
+                self.state = State::SosString
             },
             0x59..=0x5A => {
                 performer.esc_dispatch(self.intermediates(), self.ignoring, byte);


### PR DESCRIPTION
Fixes #109.

This attempts the same goal at [John-Toohey](https://github.com/John-Toohey)'s PR #110, but since this PR was was not accepted, I wanted to try another approach and see whether it is acceptable.

## Rationale for support

APC sequences are rarely supported by general-purpose terminals (if we put aside Kermit clients, tmux and screen), but there is one exception: The [Kitty Terminal Graphics Protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/). While the Kitty Image Protocol is not as ubiquitous as Sixel, it is more robust, accurate and powerful and it's implemented by several prominent terminal emulators:

* Kitty (obviously)
* Konsole
* Wezterm
* Wayst
* Ghostty

It's also supported by a large number of programs and libraries, some of them are mentioned [here](https://sw.kovidgoyal.net/kitty/graphics-protocol/).

## Design

### Design Goals

- Support SOS, PM and APC sequences (just like the original PR)
- Support streaming parsing of SOS, PM and APC sequence payloads.
- Avoid adding new conditional branches in existing code paths. This should minimize performance impact on existing code.
- Avoid re-purposing OSC state variables (in order to reduce complexity)
- Avoid adding any new stored state variable
- No embedded parsers - use existing state change tables for parsing

### Design Choices

#### Reorder actions into packable and non-packable actions

Currently, resulting state and actions are packed into an 8-bit value in the state change table (with a 4-bit nibble allocated for each). All values from 0 to 15 for both state and actions are used, so I could not add new states and action that would be _packable_. Unfortunately, I needed to support a state change with the `OpaquePut` action. The best way I've found is to separate the integer values of actions that do not need to be packed into the state change table (such as `Hook, `Unhook` and `Clear`) into a value higher than 15 and reserve lower values for actions that need to be packed

I'm not sure if my current solution is acceptable or not but I have no other idea on how to resolve this situation without repurposing the `OscString` state and actions and re-introducing an embedded parser.

#### Action matching order

This should have minimal impact, but in order to avoid any performance impact for programs which do not use APC sequences, I made sure that when matching APC/SOS/PM-specific actions, they are always matched last.

#### Streaming

Unlike #110, this PR does not collect the sequence payload inside an array. Instead, the sequence payload is streamed directly to the `Perform` trait, one byte at a time. I believe this approach is more flexible and would lead to better performance overall. The key gains here are:

- Avoiding extra vector allocation for the payload (I don't want to re-use `osc_raw` and in any case we would have to increase its default size to 4096 to be compatible with the max payload size).
- Avoiding unnecessary copying when. The payload often just needs to be parsed directly. This is especially useful when sending images directly, since the image data would often just be forwarded to an image format parser anyway.

#### Names

I've changed `SosPmApcString` to `OpaqueString`, since I wanted to have a general name for all these types of sequences where the VTE parser has no understanding of the internal structure of the sequence payload. This is difference from OSC and CSI sequences where the VTE parser is aware of the high-level structure of the sequence (if not the semantics).