### PR TITLE
OSS-Fuzz: Add fuzzers for OSS-Fuzz integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ no_std = ["arrayvec"]
 serde = ["dep:serde"]
 
 [workspace]
-members = ["utf8parse", "vte_generate_state_changes"]
+members = ["utf8parse", "vte_generate_state_changes", "utf8parse/fuzz"]

--- a/utf8parse/fuzz/.gitignore
+++ b/utf8parse/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/utf8parse/fuzz/Cargo.toml
+++ b/utf8parse/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "utf8parse-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.utf8parse]
+path = ".."
+
+[[bin]]
+name = "parse"
+path = "fuzz_targets/parse.rs"
+test = false
+doc = false
+bench = false

--- a/utf8parse/fuzz/fuzz_targets/parse.rs
+++ b/utf8parse/fuzz/fuzz_targets/parse.rs
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use utf8parse::{Parser, Receiver};
+
+// Create dummy receiver for fuzzing
+struct FuzzReceiver;
+impl Receiver for FuzzReceiver {
+    fn codepoint(&mut self, _c: char) {
+        // Do nothing
+    }
+
+    fn invalid_sequence(&mut self) {
+        // Do nothing
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        // Skip this iteration if there is no data
+        return;
+    }
+
+    let mut parser = Parser::new();
+    let mut receiver = FuzzReceiver;
+
+    // Process parsing
+    fn process_byte_sequence(parser: &mut Parser, receiver: &mut FuzzReceiver, bytes: &[u8]) {
+        for &byte in bytes {
+            parser.advance(receiver, byte);
+        }
+    }
+
+    let mut remaining_data = data;
+
+    // Randomly create fuzz data with different constraint for fuzzing
+    match remaining_data.get(0) {
+        Some(&choice) => match choice % 3 {
+            0 => {
+                // Half and half
+                let half = remaining_data.len() / 2;
+                let (first_half, second_half) = remaining_data.split_at(half);
+                process_byte_sequence(&mut parser, &mut receiver, first_half);
+                process_byte_sequence(&mut parser, &mut receiver, second_half);
+            }
+            1 => {
+                // Split data into uneven portion
+                let chunk_size = (remaining_data[0] % 8) as usize + 1;
+                let (chunk, rest) = remaining_data.split_at(remaining_data.len().min(chunk_size));
+                process_byte_sequence(&mut parser, &mut receiver, chunk);
+                remaining_data = rest;
+
+                while !remaining_data.is_empty() {
+                    let chunk_size = (remaining_data[0] % 6) as usize + 1;
+                    let (chunk, rest) = remaining_data.split_at(remaining_data.len().min(chunk_size));
+                    process_byte_sequence(&mut parser, &mut receiver, chunk);
+                    remaining_data = rest;
+                }
+            }
+            2 => {
+                // Malformed input
+                let incomplete_seq = vec![0xF0];
+                process_byte_sequence(&mut parser, &mut receiver, &incomplete_seq);
+
+                let chunk_size = (remaining_data[0] % 5) as usize + 1;
+                let (chunk, _) = remaining_data.split_at(remaining_data.len().min(chunk_size));
+                process_byte_sequence(&mut parser, &mut receiver, chunk);
+            }
+            _ => {
+                // Should not reach here, fail safe
+            }
+        },
+        None => return,
+    }
+});


### PR DESCRIPTION
This PR creates a cargo fuzz directory along with a fuzzing harness. The aim is to include the utf8parse module for fuzzing under OSS-Fuzz.

Fuzzing is essentially a stress testing technique used to uncover bugs in software, and OSS-Fuzz is a free service run by Google that provides continuous fuzzing for important open-source projects. Integrating utf8parse would be beneficial in identifying potential memory corruption issues.

The only requirement for integration at this stage is an email linked to a Google account, which will be used to receive notifications when bugs are detected.

An initial integration has been submitted via https://github.com/google/oss-fuzz/pull/12627, which relies on the fuzzer being hosted upstream. This is the primary objective of this PR.