### PR TITLE
Improve attrs_from_sgr_parameters performance

### DIFF
--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -57,9 +57,9 @@ pub fn unpack(delta: u8) -> (State, Action) {
     unsafe {
         (
             // State is stored in bottom 4 bits
-            mem::transmute(delta & 0x0f),
+            mem::transmute::<u8, State>(delta & 0x0f),
             // Action is stored in top 4 bits
-            mem::transmute(delta >> 4),
+            mem::transmute::<u8, Action>(delta >> 4),
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ const MAX_OSC_RAW: usize = 1024;
 
 struct VtUtf8Receiver<'a, P: Perform>(&'a mut P, &'a mut State);
 
-impl<'a, P: Perform> utf8::Receiver for VtUtf8Receiver<'a, P> {
+impl<P: Perform> utf8::Receiver for VtUtf8Receiver<'_, P> {
     fn codepoint(&mut self, c: char) {
         self.0.print(c);
         *self.1 = State::Ground;


### PR DESCRIPTION
Instead of collecting all the data into the vector just dispatch it right away avoiding allocations.