### PR TITLE
Replace `no_std` with `std` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 ## Unreleased
 
 - Support `CSI ? 5 W` to reset tabs stops to every 8th column
+- Replaced `no_std` with a new `std` feature
+- Changed default features to include `std`
 
 ## 0.14.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ rust-version = "1.62.1"
 
 [features]
 ansi = ["log", "cursor-icon", "bitflags"]
-default = ["no_std"]
-no_std = ["arrayvec"]
+default = ["std"]
+std = ["memchr/std"]
 serde = ["dep:serde"]
 
 [dependencies]
-arrayvec = { version = "0.7.2", default-features = false, optional = true }
+arrayvec = { version = "0.7.2", default-features = false }
 bitflags = { version = "2.3.3", default-features = false, optional = true }
 cursor-icon = { version = "1.0.0", default-features = false, optional = true }
 log = { version = "0.4.17", optional = true }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -13,13 +13,13 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::fmt::{self, Display, Formatter, Write};
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use core::ops::Mul;
 use core::ops::{Add, Sub};
 use core::str::FromStr;
 use core::time::Duration;
 use core::{iter, mem, str};
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::time::Instant;
 
 use bitflags::bitflags;
@@ -67,7 +67,7 @@ impl Rgb {
     /// Implementation of [W3C's luminance algorithm].
     ///
     /// [W3C's luminance algorithm]: https://www.w3.org/TR/WCAG20/#relativeluminancedef
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn luminance(self) -> f64 {
         let channel_luminance = |channel| {
             let channel = channel as f64 / 255.;
@@ -88,7 +88,7 @@ impl Rgb {
     /// Implementation of [W3C's contrast algorithm].
     ///
     /// [W3C's contrast algorithm]: https://www.w3.org/TR/WCAG20/#contrast-ratiodef
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn contrast(self, other: Rgb) -> f64 {
         let self_luminance = self.luminance();
         let other_luminance = other.luminance();
@@ -104,7 +104,7 @@ impl Rgb {
 }
 
 // A multiply function for Rgb, as the default dim is just *2/3.
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl Mul<f32> for Rgb {
     type Output = Rgb;
 
@@ -266,7 +266,7 @@ impl<T: Timeout> Default for SyncState<T> {
 
 /// The processor wraps a `crate::Parser` to ultimately call methods on a
 /// Handler.
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 #[derive(Default)]
 pub struct Processor<T: Timeout = StdSyncHandler> {
     state: ProcessorState<T>,
@@ -275,7 +275,7 @@ pub struct Processor<T: Timeout = StdSyncHandler> {
 
 /// The processor wraps a `crate::Parser` to ultimately call methods on a
 /// Handler.
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 #[derive(Default)]
 pub struct Processor<T: Timeout> {
     state: ProcessorState<T>,
@@ -438,13 +438,13 @@ impl<'a, H: Handler + 'a, T: Timeout> Performer<'a, H, T> {
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 #[derive(Default)]
 pub struct StdSyncHandler {
     timeout: Option<Instant>,
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl StdSyncHandler {
     /// Synchronized update expiration time.
     #[inline]
@@ -453,7 +453,7 @@ impl StdSyncHandler {
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl Timeout for StdSyncHandler {
     #[inline]
     fn set_timeout(&mut self, duration: Duration) {
@@ -2438,7 +2438,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     fn contrast() {
         let rgb1 = Rgb { r: 0xFF, g: 0xFF, b: 0xFF };
         let rgb2 = Rgb { r: 0x00, g: 0x00, b: 0x00 };


### PR DESCRIPTION
The `no_std` feature has been broken since version `0.14`, since it did not disable the `std` feature of `memchr`.

To fall more in line with the general ecosystem standards, this crate changes the `no_std` feature into an `std` feature. Since `vte` should be significantly faster with this feature, it has also been enabled by default (previously `no_std` was default).

This is a breaking change, even if we ignore `no_std` consumers which aren't able to compile 0.14, since intermediate dependencies relying on the `no_std` feature will have to remove it from the manifest.

Closes #128.