### PR TITLE
Disable default-features for memchr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ arrayvec = { version = "0.7.2", default-features = false }
 bitflags = { version = "2.3.3", default-features = false, optional = true }
 cursor-icon = { version = "1.0.0", default-features = false, optional = true }
 log = { version = "0.4.17", optional = true }
-memchr = "2.7.4"
+memchr = { version = "2.7.4", default-features = false }
 serde = { version = "1.0.160", features = ["derive"], optional = true }


### PR DESCRIPTION
Trying to build vte (master branch) without std
```
vte = { git = "https://github.com/alacritty/vte", branch = "master", default-features = false }
```
fails with
```
   --> /home/ck/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/memchr-2.7.4/src/lib.rs:198:1
    |
198 | extern crate std;
    | ^^^^^^^^^^^^^^^^^ can't find crate
```
Seems memchr/std is conditionally enabled when vte/std is enabled, but is not disabled when we pass default-features=false to vte, as memchr/std is default feature itself