### PR TITLE
Copied APC support logic

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -44,9 +44,9 @@ generate_state_changes!(state_changes, {
         0x5b        => (CsiEntry, None),
         0x5d        => (OscString, None),
         0x50        => (DcsEntry, None),
-        0x58        => (SosPmApcString, None),
-        0x5e        => (SosPmApcString, None),
-        0x5f        => (SosPmApcString, None),
+        0x58        => (OpaqueString, None),
+        0x5e        => (OpaqueString, None),
+        0x5f        => (OpaqueString, None),
     },
 
     EscapeIntermediate {
@@ -152,11 +152,11 @@ generate_state_changes!(state_changes, {
         0x9c        => (Ground, None),
     },
 
-    SosPmApcString {
+    OpaqueString {
         0x00..=0x17 => (Anywhere, Ignore),
         0x19        => (Anywhere, Ignore),
         0x1c..=0x1f => (Anywhere, Ignore),
-        0x20..=0x7f => (Anywhere, Ignore),
+        0x20..=0x7f => (Anywhere, OpaquePut),
         0x9c        => (Ground, None),
     },
 


### PR DESCRIPTION
- Copied the logic from https://github.com/alacritty/vte/pull/115
- Based on the [0.13.0 commit](https://github.com/warpdotdev/vte/commit/93baa275530718867ed40e90f2fa3512c15beb72)