### PR TITLE
Activate ansi feature for docs.rs

### DIFF
--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -26,4 +26,4 @@ tasks:
   - rustdoc: |
       $HOME/.cargo/bin/rustup toolchain install nightly -c rust-docs
       cd vte
-      RUSTDOCFLAGS="--cfg docsrs -Dwarnings" $HOME/.cargo/bin/cargo +nightly doc --features=ansi --no-deps
+      RUSTDOCFLAGS="--cfg docsrs -Dwarnings" $HOME/.cargo/bin/cargo +nightly doc --all-features --no-deps

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -24,6 +24,6 @@ tasks:
       rm Cargo.lock
       $HOME/.cargo/bin/cargo +$msrv test
   - rustdoc: |
-      $HOME/.cargo/bin/rustup toolchain install nightly -c rustdoc
+      $HOME/.cargo/bin/rustup toolchain install nightly -c rust-docs
       cd vte
       RUSTDOCFLAGS="--cfg docsrs -Dwarnings" $HOME/.cargo/bin/cargo +nightly doc --features=ansi --no-deps

--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -23,3 +23,7 @@ tasks:
       $HOME/.cargo/bin/rustup toolchain install --profile minimal $msrv
       rm Cargo.lock
       $HOME/.cargo/bin/cargo +$msrv test
+  - rustdoc: |
+      $HOME/.cargo/bin/rustup toolchain install nightly -c rustdoc
+      cd vte
+      RUSTDOCFLAGS="--cfg docsrs -Dwarnings" $HOME/.cargo/bin/cargo +nightly doc --features=ansi --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ cursor-icon = { version = "1.0.0", default-features = false, optional = true }
 log = { version = "0.4.17", optional = true }
 memchr = { version = "2.7.4", default-features = false }
 serde = { version = "1.0.160", features = ["derive"], optional = true }
+
+[package.metadata.docs.rs]
+features = ["ansi"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ memchr = { version = "2.7.4", default-features = false }
 serde = { version = "1.0.160", features = ["derive"], optional = true }
 
 [package.metadata.docs.rs]
-features = ["ansi"]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! [Paul Williams' ANSI parser state machine]: https://vt100.net/emu/dec_ansi_parser
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use core::mem::MaybeUninit;
 use core::str;
@@ -38,6 +39,7 @@ use arrayvec::ArrayVec;
 mod params;
 
 #[cfg(feature = "ansi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
 pub mod ansi;
 pub use params::{Params, ParamsIter};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl<const OSC_RAW_BUF_SIZE: usize> Parser<OSC_RAW_BUF_SIZE> {
     ///
     /// Returns the number of bytes read before termination.
     ///
-    /// See [`Perform::advance`] for more details.
+    /// See [`Self::advance`] for more details.
     #[inline]
     #[must_use = "Returned value should be used to processs the remaining bytes"]
     pub fn advance_until_terminated<P: Perform>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! [Paul Williams' ANSI parser state machine]: https://vt100.net/emu/dec_ansi_parser
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::mem::MaybeUninit;
 use core::str;
@@ -39,7 +39,6 @@ use arrayvec::ArrayVec;
 mod params;
 
 #[cfg(feature = "ansi")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ansi")))]
 pub mod ansi;
 pub use params::{Params, ParamsIter};
 


### PR DESCRIPTION
Apply:
https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577/3
And update build script accordingly
Currently, there is a warning:
```
warning: unresolved link to `Perform::advance`
   --> src/lib.rs:139:15
    |
139 |     /// See [`Perform::advance`] for more details.
    |               ^^^^^^^^^^^^^^^^ the trait `Perform` has no associated item named `advance`
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `vte` (lib doc) generated 1 warning
```
But I am not sure if the link should be on `Parser::advance` or `Perfom::terminated`.