### PR TITLE
Add Clone+Debug derives to vte::Parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ const MAX_OSC_RAW: usize = 1024;
 ///
 /// Generic over the value for the size of the raw Operating System Command
 /// buffer. Only used when the `std` feature is not enabled.
-#[derive(Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Parser<const OSC_RAW_BUF_SIZE: usize = MAX_OSC_RAW> {
     state: State,
     intermediates: [u8; MAX_INTERMEDIATES],

--- a/src/params.rs
+++ b/src/params.rs
@@ -4,7 +4,7 @@ use core::fmt::{self, Debug, Formatter};
 
 pub(crate) const MAX_PARAMS: usize = 32;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Params {
     /// Number of subparameters for each parameter.
     ///


### PR DESCRIPTION
I wonder whether it's reasonable?

Take care.