### PR TITLE
 Add serde support for cursor and charset types in ansi.rs

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1188,6 +1188,7 @@ pub enum Attr {
 
 /// Identifiers which can be assigned to a graphic character set.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CharsetIndex {
     /// Default set, is designated as ASCII at startup.
     #[default]
@@ -1199,6 +1200,7 @@ pub enum CharsetIndex {
 
 /// Standard or common character sets which can be designated as G0-G3.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StandardCharset {
     #[default]
     Ascii,


### PR DESCRIPTION
These types are missing `Serialize`/`Deserialize` derives under the `serde` feature flag, unlike other enums in `ansi.rs` (`Color`, `NamedColor`, `Rgb`).

Without the derives, downstream consumers serialising terminal state are forced to `#[serde(skip)]` fields containing these types. (such as alacritty-terminal with serde-based serialisation related to `Term` state.). This silently resets charset designations to G0/ASCII on deserialization — an application using DEC Special Graphics for box-drawing via G1 would render garbled output after restore.

The omission is an artifact of provenance: when `ansi.rs` was migrated from `alacritty_terminal` (257b925513c8bf47895dac90d8ccb815bec88492), serde derives were carried over from Alacritty's usage, where only `Grid<Cell>` was serialised. Colours were in the serialisation path (they're in every `Cell`); charsets were not (`Grid.cursor` was `serde(skip)`, and `Cursor.charsets` was never reached).
